### PR TITLE
Add structured homepage and separate vocabulary page

### DIFF
--- a/grammatik.html
+++ b/grammatik.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Grammatik</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-50 font-sans antialiased">
+  <main class="max-w-4xl mx-auto p-4">
+    <h1 class="text-3xl sm:text-4xl font-bold mb-4">Grammatik</h1>
+    <p class="mb-6">Inhalt folgt bald.</p>
+    <a href="index.html" class="text-indigo-600 dark:text-indigo-400 font-semibold hover:underline">Zurück zur Startseite</a>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,15 +3,33 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Deutscher Wortschatz</title>
+  <title>Startseite</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
-<body class="bg-gray-100 dark:bg-gray-900">
-  <div id="root"></div>
-  <script type="module" src="./src/main.js"></script>
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-50 font-sans antialiased">
+  <header class="py-10 text-center">
+    <h1 class="text-4xl sm:text-5xl font-extrabold text-indigo-800 dark:text-indigo-400 drop-shadow-md">Willkommen</h1>
+  </header>
+  <main class="max-w-4xl mx-auto p-4 space-y-10">
+    <section id="grammatik" class="bg-white dark:bg-gray-800 shadow-md rounded-xl p-6">
+      <h2 class="text-2xl font-bold mb-2">Grammatik</h2>
+      <p class="mb-4">Material zur deutschen Grammatik.</p>
+      <a href="grammatik.html" class="text-indigo-600 dark:text-indigo-400 font-semibold hover:underline">Weiter zur Grammatik</a>
+    </section>
+    <section id="lernwortschatz" class="bg-white dark:bg-gray-800 shadow-md rounded-xl p-6">
+      <h2 class="text-2xl font-bold mb-2">Lernwortschatz</h2>
+      <p class="mb-4">Übe deinen Wortschatz mit einer interaktiven Tabelle.</p>
+      <a href="lernwortschatz.html" class="text-indigo-600 dark:text-indigo-400 font-semibold hover:underline">Zur Wortschatzliste</a>
+    </section>
+    <section id="woerter" class="bg-white dark:bg-gray-800 shadow-md rounded-xl p-6">
+      <h2 class="text-2xl font-bold mb-2">Wörter</h2>
+      <p class="mb-4">Weitere Sammlungen von Wörtern.</p>
+      <a href="woerter.html" class="text-indigo-600 dark:text-indigo-400 font-semibold hover:underline">Zu den Wörtern</a>
+    </section>
+  </main>
 </body>
 </html>

--- a/lernwortschatz.html
+++ b/lernwortschatz.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lernwortschatz</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="bg-gray-100 dark:bg-gray-900">
+  <nav class="p-4">
+    <a href="index.html" class="text-indigo-600 dark:text-indigo-400 font-semibold hover:underline">Zur Startseite</a>
+  </nav>
+  <div id="root"></div>
+  <script type="module" src="./src/main.js"></script>
+</body>
+</html>

--- a/woerter.html
+++ b/woerter.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Wörter</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-50 font-sans antialiased">
+  <main class="max-w-4xl mx-auto p-4">
+    <h1 class="text-3xl sm:text-4xl font-bold mb-4">Wörter</h1>
+    <p class="mb-6">Inhalt folgt bald.</p>
+    <a href="index.html" class="text-indigo-600 dark:text-indigo-400 font-semibold hover:underline">Zurück zur Startseite</a>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Create a new landing page with sections for Grammar, Vocabulary, and Words.
- Move the existing vocabulary table into a dedicated `lernwortschatz.html` page and add simple navigation.
- Add placeholder pages for Grammar and Words.

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6890e5e282d08326afda536c38ff12d5